### PR TITLE
Change to point awards for 2-1 series

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,10 @@ Each league consists of many divisions, ordered by competitiveness, with Divisio
 ### Standings
       
 Division standings are ordered by points. Teams earn points only in their weekly division match. Each map win in the match earns a team 1 point in the standings, with a bonus point being awarded for 2-0 sweep. This means the following match results award the following points:
-
-2-0 = 3 pts
-2-1 = 2 pts
-1-2 = 1 pts
-0-2 = 0 pts
+- 2-0 = 3 pts
+- 2-1 = 2 pts
+- 1-2 = 1 pts
+- 0-2 = 0 pts
 
 ### Season Rating
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Each league consists of many divisions, ordered by competitiveness, with Divisio
 
 ### Standings
       
-Division standings are ordered by points. Teams earn points only in their weekly division match. Wins will reward +3 points while losses will not reward any points.
+Division standings are ordered by points. Teams earn points only in their weekly division match. A 2-0 win will reward +3 points. A 2-1 win will reward +2 points. A 1-2 loss will reward +1 point while 0-2 losses will not reward any points.
 
 ### Season Rating
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,12 @@ Each league consists of many divisions, ordered by competitiveness, with Divisio
 
 ### Standings
       
-Division standings are ordered by points. Teams earn points only in their weekly division match. A 2-0 win will reward +3 points. A 2-1 win will reward +2 points. A 1-2 loss will reward +1 point while 0-2 losses will not reward any points.
+Division standings are ordered by points. Teams earn points only in their weekly division match. Each map win in the match earns a team 1 point in the standings, with a bonus point being awarded for 2-0 sweep. This means the following match results award the following points:
+
+2-0 = 3 pts
+2-1 = 2 pts
+1-2 = 1 pts
+0-2 = 0 pts
 
 ### Season Rating
 


### PR DESCRIPTION
Based off discussion in the issues section.  Awarding the winners of a 2-1 series 2 points and the losers 1 point more accurately represents the quality difference of the two teams. With scheduling similar skilled teams this will allow for differentiation between several 4-4 teams for playoff qualification tiebreaks and seeding. Those who took more games in their losses are rewarded. Those who sweep their series but therefore give up playing an extra game are also rewarded.